### PR TITLE
add SlimAdamW optimizer

### DIFF
--- a/install_slimadamw.sh
+++ b/install_slimadamw.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# install AxoNN (dependency for SlimAdamW)
+git clone git@github.com:axonn-ai/axonn.git
+cd axonn
+pip install -e .
+
+cd ..
+
+# install SlimAdamW
+git clone https://github.com/axonn-ai/SlimAdamW.git
+cd SlimAdamW
+pip install -e .
+
+cd ..

--- a/install_slimadamw.sh
+++ b/install_slimadamw.sh
@@ -3,6 +3,7 @@
 # install AxoNN (dependency for SlimAdamW)
 git clone git@github.com:axonn-ai/axonn.git
 cd axonn
+git checkout new-easy-api
 pip install -e .
 
 cd ..

--- a/train.py
+++ b/train.py
@@ -33,6 +33,8 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from liger_kernel.transformers.monkey_patch import _apply_liger_kernel, MODEL_TYPE_TO_APPLY_LIGER_FN
 from torchao.prototype.low_bit_optim import CPUOffloadOptimizer
 
+import slimadamw
+
 import functools
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
         checkpoint_wrapper,
@@ -96,6 +98,7 @@ cramming_offload_optim_cpu = True
 cramming_offload_gradients_cpu = True
 cramming_activation_checkpointing = True
 cramming_fuse_optim_backward = False
+cramming_use_slimadamw = False
 using_preemptible = False # whether running on a preemptible instance
 # -----------------------------------------------------------------------------
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
@@ -154,8 +157,16 @@ def configure_optimizers(model, weight_decay, learning_rate, betas, device_type)
         optimizer = CPUOffloadOptimizer(optim_groups, torch.optim.AdamW, offload_gradients=cramming_offload_gradients_cpu, fused=use_fused, lr=learning_rate, betas=betas)
         print("Using CPU Offload Optimizer")
     else:
-        optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas, fused=use_fused)
-        print("Using PyTorch AdamW Optimizer")
+        if cramming_use_slimadamw:
+            ''' 
+            1. SlimAdamW doesn't support fusing yet
+            2. SlimAdamW requires `model` as second argument: SlimAdamW(model.parameters(), model, ...)
+            '''
+            optimizer = slimadamw.SlimAdamW(optim_groups, model, lr=learning_rate, betas=betas) 
+            print("Using SlimAdamW Optimizer")
+        else:
+            optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas, fused=use_fused)
+            print("Using PyTorch AdamW Optimizer")
     return optimizer
 
 def configure_fused_optimizers(model, weight_decay, learning_rate, betas, device_type):


### PR DESCRIPTION
This PR adds the SlimAdamW optimizer

**Notes:**
- Run `bash install_slimadamw.sh` to install SlimAdamW and its dependencies
- Set `cramming_use_slimadamw` flag to True to use SlimAdamW
- SlimAdamW
   - currently doesn't support fusing
   - takes in `model` as its second argument: `slimadamw.SlimAdamW(model.parameters(), model, lr=...)`

Currently, SlimAdamW will only be used if
```py
cramming_fuse_optim_backward = False
cramming_offload_optim_cpu = False
cramming_use_slimadamw = True
```
I've not added SlimAdamW to `configure_fused_optimizers` since it doesn't support fusing yet. Also, SlimAdamW won't work with `CPUOffloadOptimizer` right now because it also takes `model` as an argument, so I'm guessing a wrapper class is needed to make this work.